### PR TITLE
Tweak README and bilevel docs (#19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**Marguerite.jl** is a minimal, performant, and differentiable Frank-Wolfe (conditional gradient) solver for constrained convex optimization. Named after Marguerite Frank (1927--), co-inventor of the Frank-Wolfe algorithm (1956).
+**Marguerite.jl** is a minimal, performant, and differentiable Frank-Wolfe (conditional gradient) solver for constrained convex optimization. Named in honor of Marguerite Frank (1927–2024), co-inventor of the Frank-Wolfe algorithm (1956).
 
 ## Build and Development Commands
 
@@ -29,7 +29,7 @@ julia --project=docs docs/make.jl
 src/
   Marguerite.jl     # Module file: includes, exports
   types.jl          # Result, Cache, MonotonicStepSize, AdaptiveStepSize
-  lmo.jl            # LinearOracle abstract type + 5 concrete oracles
+  lmo.jl            # AbstractOracle abstract type + 6 oracle constructors
   solver.jl         # solve() -- core Frank-Wolfe loop (4 method signatures)
   diff_rules.jl     # ChainRulesCore rrule for implicit differentiation
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/src/assets/logo.svg" width="200"/>
+  <img src="docs/src/assets/logo.svg" width="320"/>
 </p>
 
 # Marguerite.jl
@@ -11,69 +11,51 @@ Named in honor of [Marguerite Frank](https://en.wikipedia.org/wiki/Marguerite_Fr
 [![Docs](https://img.shields.io/badge/docs-blue.svg)](https://samueltalkington.com/research/marguerite/)
 [![Build Status](https://github.com/samtalki/Marguerite.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/samtalki/Marguerite.jl/actions/workflows/CI.yml?query=branch%3Amain)
 
-## The Problem
-`Marguerite.jl` solves constrained optimization programs that take the form
+Solves constrained convex programs of the form
+
 $$\min_{x \in \mathcal{C}} f(x)$$
 
-where $\mathcal{C}$ is a compact convex set. Frank-Wolfe solves these problems using a **linear minimization oracle** (LMO) -- no projections, just $\arg\min_{v \in \mathcal{C}} \langle g, v \rangle$ at each step.
+where $\mathcal{C}$ is a compact convex set accessed through a **linear minimization oracle** (LMO).
 
 ## Quick Start
+
+With a user-provided gradient:
 
 ```julia
 using Marguerite, LinearAlgebra
 
-Q = [2.0 0.5; 0.5 1.0]; c = [-1.0, -0.5]
+Q = [4.0 1.0; 1.0 2.0]; c = [-3.0, -1.0]
 f(x) = 0.5 * dot(x, Q * x) + dot(c, x)
 ∇f!(g, x) = (g .= Q * x .+ c)
 
 x, result = solve(f, ∇f!, ProbabilitySimplex(), [0.5, 0.5])
 ```
 
-Or skip the gradient -- Marguerite computes it automatically via [ForwardDiff](https://github.com/JuliaDiff/ForwardDiff.jl):
+Omit `∇f!` for automatic differentiation via [ForwardDiff](https://github.com/JuliaDiff/ForwardDiff.jl). For bilevel optimization, `bilevel_solve` differentiates through the solver to compute $\nabla_\theta L(x^*(\theta))$:
 
 ```julia
-x, result = solve(f, ProbabilitySimplex(), [0.5, 0.5])
+x_target = [1.0, 0.0]; x0 = [0.5, 0.5]; θ = [0.8, 0.2]; η = 0.01
+
+f(x, θ) = 0.5 * dot(x, x) - dot(θ, x)
+∇f!(g, x, θ) = (g .= x .- θ)
+outer_loss(x) = sum((x .- x_target).^2)
+
+x_star, θ_grad, _ = bilevel_solve(outer_loss, f, ∇f!, ProbabilitySimplex(), x0, θ)
+θ .-= η .* θ_grad
 ```
 
 ## Features
 
-- **`solve` is the entire API.** Manual or automatic gradients, with or without differentiable parameters.
-- **Zero-allocation inner loop.** Pre-allocated `Cache` buffers, `@inbounds` hot paths.
-- **Any callable oracle.** Any `(v, g) -> v` works -- no subtyping required. Five built-in oracles cover simplices, knapsacks, boxes, and weighted simplices. See the [oracle documentation](https://samueltalkington.com/research/marguerite/oracles/).
-- **Differentiable solve.** Custom `ChainRulesCore.rrule` implementations make it easy to compute $\partial x^{\ast} / \partial \theta$ via implicit differentiation -- no unrolling through iterations.
-- **Bilevel optimization.** `bilevel_solve` backpropagates through the solver to learn parameters of constrained problems.
+- Single entry point: `solve(f, ∇f!, lmo, x0; ...)`, with or without automatic gradients and differentiable parameters
+- Pre-allocated buffers for allocation-free inner loops (`@inbounds` hot paths)
+- Six built-in oracles: simplex, probability simplex, knapsack, masked knapsack, box, weighted simplex
+- Custom oracles: any `(v, g) -> v` callable works, no subtyping required
+- Differentiable solve via `ChainRulesCore.rrule` for $\partial x^* / \partial \theta$ (implicit differentiation)
+- Bilevel optimization: `bilevel_solve` backpropagates through the solver to learn parameters of constrained problems
 
-```julia
-# Manual gradient:
-x, result = solve(f, ∇f!, lmo, x0; max_iters=1000, tol=1e-7)
+## Documentation
 
-# Auto gradient (ForwardDiff default):
-x, result = solve(f, lmo, x0)
-
-# Parameterized (differentiable w.r.t. θ):
-x, result = solve(f, ∇f!, lmo, x0, θ)
-
-# Auto gradient + differentiable:
-x, result = solve(f, lmo, x0, θ)
-```
-
-## Bilevel Optimization
-
-$$\min_\theta \; L(x^{\ast}(\theta)) \quad \text{s.t.} \quad x^{\ast}(\theta) = \arg\min_{x \in \mathcal{C}} f(x, \theta)$$
-
-```julia
-using Marguerite, LinearAlgebra
-
-f(x, θ) = 0.5 * dot(x, x) - dot(θ, x)
-∇f!(g, x, θ) = (g .= x .- θ)
-outer_loss(x) = sum((x .- x_target) .^ 2)
-
-x_star, θ_grad, cg_result = bilevel_solve(outer_loss, f, ∇f!, ProbSimplex(), x0, θ;
-                                          max_iters=5000, tol=1e-6)
-θ .-= η .* θ_grad  # ∇_θ L(x*(θ))
-```
-
-Exact gradients at convergence via the implicit function theorem. The Hessian system is solved by conjugate gradient with Hessian-vector products -- no explicit Hessian construction. See the [bilevel documentation](https://samueltalkington.com/research/marguerite/bilevel/).
+See the [full documentation](https://samueltalkington.com/research/marguerite/) for tutorials, examples, and API reference.
 
 ## Installation
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -45,11 +45,11 @@ makedocs(;
     pages=[
         "Home" => "index.md",
         "Tutorial" => "tutorial.md",
-        "Bilevel Optimization" => "bilevel.md",
-        "Convergence" => "convergence.md",
-        "Examples" => "examples.md",
         "Oracles" => "oracles.md",
+        "Examples" => "examples.md",
+        "Convergence" => "convergence.md",
         "Differentiation" => "differentiation.md",
+        "Bilevel Optimization" => "bilevel.md",
         "API Reference" => "api.md",
     ],
 )

--- a/docs/src/assets/box.svg
+++ b/docs/src/assets/box.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 160" width="200" height="160">
+  <!-- axes -->
+  <line x1="20" y1="140" x2="185" y2="140" stroke="#888" stroke-width="1"/>
+  <line x1="20" y1="140" x2="20" y2="10" stroke="#888" stroke-width="1"/>
+  <polygon points="185,140 179,137 179,143" fill="#888"/>
+  <polygon points="20,10 17,16 23,16" fill="#888"/>
+  <text x="188" y="144" font-size="11" fill="#555" font-family="serif" font-style="italic">x&#x2081;</text>
+  <text x="8" y="10" font-size="11" fill="#555" font-family="serif" font-style="italic">x&#x2082;</text>
+  <!-- box: [l1,u1] x [l2,u2] -->
+  <rect x="50" y="30" width="110" height="80" fill="#e8f0fe" stroke="#1a73e8" stroke-width="1.5"/>
+  <!-- tick marks and labels -->
+  <line x1="50" y1="140" x2="50" y2="136" stroke="#888" stroke-width="1"/>
+  <line x1="160" y1="140" x2="160" y2="136" stroke="#888" stroke-width="1"/>
+  <line x1="20" y1="110" x2="24" y2="110" stroke="#888" stroke-width="1"/>
+  <line x1="20" y1="30" x2="24" y2="30" stroke="#888" stroke-width="1"/>
+  <text x="45" y="152" font-size="9" fill="#333" font-family="serif" font-style="italic">l&#x2081;</text>
+  <text x="155" y="152" font-size="9" fill="#333" font-family="serif" font-style="italic">u&#x2081;</text>
+  <text x="3" y="114" font-size="9" fill="#333" font-family="serif" font-style="italic">l&#x2082;</text>
+  <text x="3" y="34" font-size="9" fill="#333" font-family="serif" font-style="italic">u&#x2082;</text>
+  <!-- corner dots -->
+  <circle cx="50" cy="110" r="2.5" fill="#1a73e8"/>
+  <circle cx="160" cy="110" r="2.5" fill="#1a73e8"/>
+  <circle cx="50" cy="30" r="2.5" fill="#1a73e8"/>
+  <circle cx="160" cy="30" r="2.5" fill="#1a73e8"/>
+</svg>

--- a/docs/src/assets/knapsack.svg
+++ b/docs/src/assets/knapsack.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 160" width="200" height="160">
+  <!-- axes -->
+  <line x1="30" y1="130" x2="185" y2="130" stroke="#888" stroke-width="1"/>
+  <line x1="30" y1="130" x2="30" y2="10" stroke="#888" stroke-width="1"/>
+  <polygon points="185,130 179,127 179,133" fill="#888"/>
+  <polygon points="30,10 27,16 33,16" fill="#888"/>
+  <text x="188" y="134" font-size="11" fill="#555" font-family="serif" font-style="italic">x&#x2081;</text>
+  <text x="18" y="10" font-size="11" fill="#555" font-family="serif" font-style="italic">x&#x2082;</text>
+  <!-- unit square marks -->
+  <line x1="160" y1="130" x2="160" y2="126" stroke="#888" stroke-width="1"/>
+  <line x1="30" y1="25" x2="34" y2="25" stroke="#888" stroke-width="1"/>
+  <text x="157" y="143" font-size="9" fill="#333" font-family="sans-serif">1</text>
+  <text x="17" y="29" font-size="9" fill="#333" font-family="sans-serif">1</text>
+  <!-- feasible region: [0,1]^2 intersected with x1+x2 <= k (k~1.4) -->
+  <!-- Pentagon: (0,0), (1,0), (1,k-1), (k-1,1), (0,1) with k=1.4 -->
+  <!-- mapped: 0->30, 1->160, k-1=0.4->82 -->
+  <polygon points="30,130 160,130 160,78 82,25 30,25" fill="#e8f0fe" stroke="#1a73e8" stroke-width="1.5"/>
+  <!-- budget hyperplane label -->
+  <text x="115" y="30" font-size="10" fill="#1a73e8" font-family="serif" font-style="italic" transform="rotate(-34, 138, 30)">x&#x2081;+x&#x2082; = k</text>
+  <!-- dashed unit square outline -->
+  <rect x="30" y="25" width="130" height="105" fill="none" stroke="#ccc" stroke-width="1" stroke-dasharray="4,3"/>
+</svg>

--- a/docs/src/assets/knapsack_masked.svg
+++ b/docs/src/assets/knapsack_masked.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 160" width="200" height="160">
+  <!-- axes -->
+  <line x1="30" y1="130" x2="185" y2="130" stroke="#888" stroke-width="1"/>
+  <line x1="30" y1="130" x2="30" y2="10" stroke="#888" stroke-width="1"/>
+  <polygon points="185,130 179,127 179,133" fill="#888"/>
+  <polygon points="30,10 27,16 33,16" fill="#888"/>
+  <text x="188" y="134" font-size="11" fill="#555" font-family="serif" font-style="italic">x&#x2081;</text>
+  <text x="18" y="10" font-size="11" fill="#555" font-family="serif" font-style="italic">x&#x2082;</text>
+  <!-- tick marks -->
+  <line x1="160" y1="130" x2="160" y2="126" stroke="#888" stroke-width="1"/>
+  <line x1="30" y1="25" x2="34" y2="25" stroke="#888" stroke-width="1"/>
+  <text x="157" y="143" font-size="9" fill="#333" font-family="sans-serif">1</text>
+  <text x="17" y="29" font-size="9" fill="#333" font-family="sans-serif">1</text>
+  <!-- dashed unit square -->
+  <rect x="30" y="25" width="130" height="105" fill="none" stroke="#ccc" stroke-width="1" stroke-dasharray="4,3"/>
+  <!-- dashed full knapsack pentagon for reference -->
+  <polygon points="30,130 160,130 160,78 82,25 30,25" fill="none" stroke="#ccc" stroke-width="1" stroke-dasharray="4,3"/>
+  <!-- x1=1 forced: vertical slice at x1=1 within knapsack -->
+  <!-- x1=1 maps to x=160. Budget x1+x2<=k with k=1.4, so x2<=0.4 -->
+  <!-- x2 range: [0, 0.4], i.e. y: [130, 78] -->
+  <line x1="160" y1="130" x2="160" y2="78" stroke="#1a73e8" stroke-width="2.5"/>
+  <circle cx="160" cy="130" r="3" fill="#1a73e8"/>
+  <circle cx="160" cy="78" r="3" fill="#1a73e8"/>
+  <!-- labels -->
+  <text x="105" y="105" font-size="9" fill="#1a73e8" font-family="sans-serif">x&#x2081;=1</text>
+  <text x="163" y="134" font-size="8" fill="#333" font-family="sans-serif">(1, 0)</text>
+  <text x="163" y="75" font-size="8" fill="#333" font-family="sans-serif">(1, k&#x2212;1)</text>
+  <!-- shaded knapsack region for context -->
+  <polygon points="30,130 160,130 160,78 82,25 30,25" fill="#e8f0fe" fill-opacity="0.3" stroke="none"/>
+</svg>

--- a/docs/src/assets/simplex_capped.svg
+++ b/docs/src/assets/simplex_capped.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 160" width="200" height="160">
+  <!-- axes -->
+  <line x1="30" y1="130" x2="185" y2="130" stroke="#888" stroke-width="1"/>
+  <line x1="30" y1="130" x2="30" y2="10" stroke="#888" stroke-width="1"/>
+  <polygon points="185,130 179,127 179,133" fill="#888"/>
+  <polygon points="30,10 27,16 33,16" fill="#888"/>
+  <text x="188" y="134" font-size="11" fill="#555" font-family="serif" font-style="italic">x&#x2081;</text>
+  <text x="18" y="10" font-size="11" fill="#555" font-family="serif" font-style="italic">x&#x2082;</text>
+  <!-- feasible region: triangle (0,0), (r,0), (0,r) -->
+  <polygon points="30,130 160,130 30,25" fill="#e8f0fe" stroke="#1a73e8" stroke-width="1.5"/>
+  <!-- vertex labels -->
+  <text x="22" y="143" font-size="9" fill="#333" font-family="sans-serif">0</text>
+  <text x="152" y="143" font-size="9" fill="#333" font-family="sans-serif">(r, 0)</text>
+  <text x="34" y="22" font-size="9" fill="#333" font-family="sans-serif">(0, r)</text>
+  <!-- x&#x2081; + x&#x2082; &#x2264; r label -->
+  <text x="108" y="58" font-size="10" fill="#1a73e8" font-family="serif" font-style="italic" transform="rotate(-39, 130, 58)">x&#x2081;+x&#x2082; &#x2264; r</text>
+</svg>

--- a/docs/src/assets/simplex_prob.svg
+++ b/docs/src/assets/simplex_prob.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 160" width="200" height="160">
+  <!-- axes -->
+  <line x1="30" y1="130" x2="185" y2="130" stroke="#888" stroke-width="1"/>
+  <line x1="30" y1="130" x2="30" y2="10" stroke="#888" stroke-width="1"/>
+  <polygon points="185,130 179,127 179,133" fill="#888"/>
+  <polygon points="30,10 27,16 33,16" fill="#888"/>
+  <text x="188" y="134" font-size="11" fill="#555" font-family="serif" font-style="italic">x&#x2081;</text>
+  <text x="18" y="10" font-size="11" fill="#555" font-family="serif" font-style="italic">x&#x2082;</text>
+  <!-- feasible set: line from (r,0) to (0,r) -->
+  <line x1="160" y1="130" x2="30" y2="25" stroke="#1a73e8" stroke-width="2"/>
+  <!-- vertex dots -->
+  <circle cx="160" cy="130" r="3" fill="#1a73e8"/>
+  <circle cx="30" cy="25" r="3" fill="#1a73e8"/>
+  <!-- vertex labels -->
+  <text x="152" y="143" font-size="9" fill="#333" font-family="sans-serif">(r, 0)</text>
+  <text x="34" y="22" font-size="9" fill="#333" font-family="sans-serif">(0, r)</text>
+  <!-- constraint label -->
+  <text x="108" y="58" font-size="10" fill="#1a73e8" font-family="serif" font-style="italic" transform="rotate(-39, 130, 58)">x&#x2081;+x&#x2082; = r</text>
+</svg>

--- a/docs/src/assets/weighted_simplex.svg
+++ b/docs/src/assets/weighted_simplex.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 160" width="200" height="160">
+  <!-- axes -->
+  <line x1="20" y1="140" x2="185" y2="140" stroke="#888" stroke-width="1"/>
+  <line x1="20" y1="140" x2="20" y2="10" stroke="#888" stroke-width="1"/>
+  <polygon points="185,140 179,137 179,143" fill="#888"/>
+  <polygon points="20,10 17,16 23,16" fill="#888"/>
+  <text x="188" y="144" font-size="11" fill="#555" font-family="serif" font-style="italic">x&#x2081;</text>
+  <text x="8" y="10" font-size="11" fill="#555" font-family="serif" font-style="italic">x&#x2082;</text>
+  <!-- lower bound point -->
+  <line x1="55" y1="140" x2="55" y2="136" stroke="#888" stroke-width="1"/>
+  <line x1="20" y1="105" x2="24" y2="105" stroke="#888" stroke-width="1"/>
+  <text x="48" y="152" font-size="9" fill="#333" font-family="serif" font-style="italic">l&#x2081;</text>
+  <text x="3" y="109" font-size="9" fill="#333" font-family="serif" font-style="italic">l&#x2082;</text>
+  <!-- feasible region: triangle from lb shifted, tilted budget hyperplane -->
+  <!-- vertices: (l1,l2), (l1 + beta_bar/a1, l2), (l1, l2 + beta_bar/a2) -->
+  <!-- with asymmetric weights a1 > a2, the simplex tilts -->
+  <polygon points="55,105 160,105 55,30" fill="#e8f0fe" stroke="#1a73e8" stroke-width="1.5"/>
+  <!-- lower-bound corner -->
+  <circle cx="55" cy="105" r="3" fill="#1a73e8"/>
+  <text x="59" y="118" font-size="8" fill="#333" font-family="sans-serif">(l&#x2081;, l&#x2082;)</text>
+  <!-- budget hyperplane -->
+  <text x="118" y="48" font-size="9" fill="#1a73e8" font-family="serif" font-style="italic" transform="rotate(-35, 140, 48)">&#x27E8;&#x03B1;, x&#x27E9; = &#x03B2;</text>
+  <!-- vertex labels -->
+  <text x="130" y="120" font-size="8" fill="#333" font-family="sans-serif">l&#x2081;+&#x03B2;&#x0304;/&#x03B1;&#x2081;</text>
+  <text x="59" y="27" font-size="8" fill="#333" font-family="sans-serif">l&#x2082;+&#x03B2;&#x0304;/&#x03B1;&#x2082;</text>
+</svg>

--- a/docs/src/bilevel.md
+++ b/docs/src/bilevel.md
@@ -17,7 +17,7 @@ Examples include hyperparameter tuning, meta-learning, adversarial training,
 and inverse optimization. Projects like Meta's Theseus and `cvxpylayers` have
 shown that **differentiable optimization layers** are a powerful primitive.
 
-Marguerite brings this to **constrained** problems via Frank-Wolfe's
+Marguerite supports constrained bilevel problems via Frank-Wolfe's
 projection-free approach: any set with a linear minimization oracle works,
 no projection operator needed.
 
@@ -63,17 +63,17 @@ x_target[1] = 0.6; x_target[2] = 0.3; x_target[3] = 0.1
 
 outer_loss(x) = sum((x .- x_target).^2)
 θ = H * x_target
-η = 0.1
+η = 0.01
 
 losses = Float64[]
 for k in 1:80
     x_star, θ_grad, _ = bilevel_solve(outer_loss, f, ∇f!, lmo, x0, θ;
-                                       max_iters=10000, tol=1e-6)
+                                       max_iters=10000, tol=1e-4)
     push!(losses, outer_loss(x_star))
     θ .= θ .- η .* θ_grad
 end
 
-x_final, _ = solve(f, ∇f!, lmo, x0, θ; max_iters=10000, tol=1e-6)
+x_final, _ = solve(f, ∇f!, lmo, x0, θ; max_iters=10000, tol=1e-4)
 println("Final loss: ", round(losses[end]; sigdigits=3))
 println("x*(θ):     ", round.(x_final; digits=3))
 println("x_target:  ", x_target)
@@ -82,7 +82,7 @@ println("x_target:  ", x_target)
 For just the gradient (without the solution), use `bilevel_gradient`:
 
 ```julia
-θ_grad = bilevel_gradient(outer_loss, f, ∇f!, lmo, x0, θ; max_iters=10000, tol=1e-6)
+θ_grad = bilevel_gradient(outer_loss, f, ∇f!, lmo, x0, θ; max_iters=10000, tol=1e-4)
 ```
 
 Both functions accept `diff_cg_maxiter`, `diff_cg_tol`, and `diff_λ` to tune
@@ -110,7 +110,7 @@ x^*(\theta) = \arg\min_{x \in \Delta_n} \;\tfrac{1}{2} x^\top H x - \theta^\top 
 ```@example bilevel
 using ChainRulesCore: rrule
 
-solve_kw = (; max_iters=10000, tol=1e-6)
+solve_kw = (; max_iters=10000, tol=1e-4)
 
 nothing  # hide
 ```
@@ -134,7 +134,7 @@ Run gradient descent on the outer problem:
 
 ```@example bilevel
 θ = H * x_target  # warm start
-η = 0.1
+η = 0.01
 
 losses = Float64[]
 for k in 1:80
@@ -159,7 +159,7 @@ lineplot(1:80, log10.(losses);
 
 ## Why Frank-Wolfe for bilevel?
 
-Frank-Wolfe is uniquely suited to bilevel optimization with complex constraints:
+Frank-Wolfe has properties that suit bilevel optimization with complex constraints:
 
 1. **Projection-free**: Only needs a linear minimization oracle, not a projection.
    Many constraint sets (matroid polytopes, flow polytopes, nuclear norm balls)

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -3,7 +3,7 @@
 
 # Examples
 
-## Sparse Recovery: When Frank-Wolfe Beats Interior Point
+## Sparse Recovery on the Simplex
 
 Consider sparse recovery on the probability simplex:
 
@@ -95,7 +95,7 @@ x0 = zeros(n); x0[1] = 1.0
 nothing  # hide
 ```
 
-## Convergence
+## Convergence trace
 
 We trace the FW gap over iterations to see the ``O(1/t)`` decay, then report
 the final solution quality:
@@ -151,8 +151,8 @@ QP solver via JuMP) on increasingly large problems. Results from
 | m=100, n=20,000 | **3.8 s**, 625 KiB | prohibitive |
 | m=100, n=50,000 | **15.5 s**, 1.5 MiB | prohibitive |
 
-Marguerite is **5,000× faster** on the smallest problem and scales to dimensions
-where interior-point methods cannot even allocate the Hessian.
+On the smallest problem, the Frank-Wolfe solver is approximately 5000× faster
+and scales to dimensions where interior-point methods cannot even allocate the Hessian.
 
 ## Why the difference
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,61 +11,30 @@ A minimal, differentiable Frank-Wolfe solver for constrained convex optimization
 
 Named in honor of [Marguerite Frank](https://en.wikipedia.org/wiki/Marguerite_Frank) (1927–2024), co-inventor of the Frank-Wolfe algorithm (1956).
 
-## What is Marguerite.jl?
-
-Marguerite.jl provides a single entry point, [`solve`](@ref), for constrained convex minimization via the conditional gradient (Frank-Wolfe) method:
-
-```math
-\min_{x \in \mathcal{C}} f(x)
-```
-
-where ``\mathcal{C}`` is a compact convex set accessed through a **linear minimization oracle** (LMO). 100% pure Julia.
-
-### Key features
-
-- **One function:** `solve(f, ∇f!, lmo, x0; ...)`, that's the entire API
-- **100% pure Julia:** easy to read, audit, and extend
-- **Six built-in oracles:** [`Simplex`](@ref) (+ [`ProbabilitySimplex`](@ref) alias), [`Knapsack`](@ref), [`MaskedKnapsack`](@ref), [`Box`](@ref), [`WeightedSimplex`](@ref)
-- **Zero-allocation inner loop:** pre-allocated [`Cache`](@ref) buffers, `@inbounds` hot paths
-- **Auto-gradient:** optional automatic differentiation via [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) through [DifferentiationInterface.jl](https://github.com/JuliaDiff/DifferentiationInterface.jl)
-- **Differentiable solve:** `ChainRulesCore.rrule` for ``\partial x^* / \partial \theta`` via implicit differentiation
-- **Bring your own oracle:** any callable `(v, g) -> v` works, no subtyping required
-
-### The killer app: bilevel optimization
-
-Marguerite's differentiable `solve` enables **bilevel optimization** — learning
-parameters of constrained problems by backpropagating through the solver.
-No unrolling. ``O(1)`` memory. Exact gradients at convergence.
-
-```math
-\min_\theta \; L(x^*(\theta)) \quad \text{s.t.} \quad x^*(\theta) = \arg\min_{x \in \mathcal{C}} f(x, \theta)
-```
-
-```julia
-using Marguerite, LinearAlgebra
-
-f(x, θ) = 0.5 * dot(x, x) - dot(θ, x)
-∇f!(g, x, θ) = (g .= x .- θ)
-outer_loss(x) = sum((x .- x_target) .^ 2)
-
-x_star, θ_grad, cg_result = bilevel_solve(outer_loss, f, ∇f!, ProbSimplex(), x0, θ;
-                                          max_iters=5000, tol=1e-6)
-θ .-= η .* θ_grad  # ∇_θ L(x*(θ))
-```
-
-See [Bilevel Optimization](@ref) for a fully-worked example.
-
 ## Quick start
 
 ```julia
 using Marguerite, LinearAlgebra
 
-Q = [2.0 0.5; 0.5 1.0]; c = [-1.0, -0.5]
+Q = [4.0 1.0; 1.0 2.0]; c = [-3.0, -1.0]
 f(x) = 0.5 * dot(x, Q * x) + dot(c, x)
 ∇f!(g, x) = (g .= Q * x .+ c)
 
-x, result = solve(f, ∇f!, ProbabilitySimplex(), [0.5, 0.5])
+x, result = solve(f, ∇f!, ProbabilitySimplex(), [0.5, 0.5];
+                   max_iters=10000, tol=1e-3)
 ```
+
+Omit `∇f!` for automatic differentiation via ForwardDiff.
+
+## Documentation guide
+
+- **[Tutorial](@ref)** — basic usage, automatic gradients, parameterized solve, custom oracles
+- **[Oracles](@ref)** — built-in constraint sets and the oracle interface
+- **[Examples](@ref)** — sparse recovery benchmark (Frank-Wolfe vs. interior point)
+- **[Convergence](@ref)** — ``O(1/t)`` rate, Frank-Wolfe gap, sparsity plots
+- **[Implicit Differentiation](@ref)** — implicit differentiation, rrule, CG tuning
+- **[Bilevel Optimization](@ref)** — `bilevel_solve`, `bilevel_gradient`, manual rrule usage
+- **[API Reference](@ref)** — complete docstrings for all exports
 
 ## Installation
 

--- a/docs/src/oracles.md
+++ b/docs/src/oracles.md
@@ -1,7 +1,7 @@
 <!-- Copyright 2026 Samuel Talkington and contributors
    SPDX-License-Identifier: Apache-2.0 -->
 
-# Linear Oracles
+# Oracles
 
 All oracles solve the linear minimization problem
 
@@ -10,12 +10,17 @@ v^* = \arg\min_{v \in \mathcal{C}} \langle g, v \rangle
 ```
 
 in-place via `lmo(v, g)`. Any callable `(v, g) -> v` works as an oracle.
+See the [Tutorial](@ref) for an example of writing a custom oracle.
 
 ```@docs
-LinearOracle
+AbstractOracle
 ```
 
 ## Simplex
+
+![Capped simplex constraint set](assets/simplex_capped.svg)
+
+![Probability simplex constraint set](assets/simplex_prob.svg)
 
 ```@docs
 Simplex
@@ -25,11 +30,15 @@ ProbabilitySimplex
 
 ## Knapsack
 
+![Knapsack constraint set](assets/knapsack.svg)
+
 ```@docs
 Knapsack
 ```
 
 ## MaskedKnapsack
+
+![Masked knapsack constraint set](assets/knapsack_masked.svg)
 
 ```@docs
 MaskedKnapsack
@@ -37,11 +46,15 @@ MaskedKnapsack
 
 ## Box
 
+![Box constraint set](assets/box.svg)
+
 ```@docs
 Box
 ```
 
 ## WeightedSimplex
+
+![Weighted simplex constraint set](assets/weighted_simplex.svg)
 
 ```@docs
 WeightedSimplex

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -36,14 +36,8 @@ Omit `∇f!` and the gradient is computed automatically via ForwardDiff (the def
 x, result = solve(f, ProbSimplex(), [0.5, 0.5])
 ```
 
-To use a different backend, pass `backend=`:
-
-```julia
-import DifferentiationInterface as DI
-
-x, result = solve(f, ProbSimplex(), [0.5, 0.5];
-                   backend=DI.AutoForwardDiff())
-```
+Pass `backend=` to use a different [DifferentiationInterface.jl](https://github.com/JuliaDiff/DifferentiationInterface.jl) backend.
+See [Implicit Differentiation](@ref) for details on AD backend selection.
 
 ## Parameterized solve (differentiable)
 

--- a/src/Marguerite.jl
+++ b/src/Marguerite.jl
@@ -31,7 +31,7 @@ include("bilevel.jl")
 
 export solve, Result, CGResult, MonotonicStepSize, AdaptiveStepSize, SECOND_ORDER_BACKEND
 export bilevel_solve, bilevel_gradient
-export LinearOracle, Simplex, ProbSimplex, ProbabilitySimplex, Knapsack, MaskedKnapsack, Box, WeightedSimplex
+export AbstractOracle, Simplex, ProbSimplex, ProbabilitySimplex, Knapsack, MaskedKnapsack, Box, WeightedSimplex
 
 @compile_workload begin
     # n=2 workload to precompile solver infrastructure and LMOs.

--- a/src/lmo.jl
+++ b/src/lmo.jl
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 """
-    LinearOracle
+    AbstractOracle
 
 Abstract supertype for Frank-Wolfe linear minimization oracles.
 
-Every concrete oracle `lmo <: LinearOracle` is a callable struct invoked as
+Every concrete oracle `lmo <: AbstractOracle` is a callable struct invoked as
 `lmo(v, g)`, writing the solution of ``\\min_{v \\in C} \\langle g, v \\rangle``
 into `v` in-place.
 
 Any plain function `(v, g) -> v` also works as an oracle -- no subtyping required.
 """
-abstract type LinearOracle end
+abstract type AbstractOracle end
 
 # ------------------------------------------------------------------
 # Simplex (unified: capped and probability)
@@ -44,7 +44,7 @@ Selects ``r e_{i^*}`` when ``g_{i^*} < 0``, otherwise the origin. ``O(n)``.
 **Probability** (`Equality=true`): Vertices are ``\\{r e_1, \\ldots, r e_n\\}``.
 Always selects ``r e_{i^*}`` where ``i^* = \\arg\\min_i g_i``. ``O(n)``.
 """
-struct Simplex{T<:Real, Equality} <: LinearOracle
+struct Simplex{T<:Real, Equality} <: AbstractOracle
     r::T
 end
 
@@ -97,7 +97,7 @@ Selects up to `budget` indices with most negative gradient and sets them to 1;
 only indices with strictly negative gradient are selected.
 ``O(m + k \\log k)`` where ``k = \\text{budget}``, via `partialsortperm!`.
 """
-struct Knapsack <: LinearOracle
+struct Knapsack <: AbstractOracle
     perm::Vector{Int}
     k::Int
 end
@@ -135,7 +135,7 @@ Fixes masked entries to 1, then selects up to ``k = \\text{budget} - |\\text{mas
 non-masked indices with most negative gradient; only indices with strictly
 negative gradient are selected. ``O(m + k \\log k)`` via `partialsortperm!`.
 """
-struct MaskedKnapsack <: LinearOracle
+struct MaskedKnapsack <: AbstractOracle
     is_masked::BitVector
     sel::Vector{Int}
     perm::Vector{Int}
@@ -182,7 +182,7 @@ Oracle for the box ``C = \\{x : l_i \\le x_i \\le u_i\\}``.
 
 Separable LP: ``v_i = l_i`` if ``g_i \\ge 0``, else ``v_i = u_i``. ``O(n)``.
 """
-struct Box{T<:Real} <: LinearOracle
+struct Box{T<:Real} <: AbstractOracle
     lb::Vector{T}
     ub::Vector{T}
 end
@@ -211,7 +211,7 @@ Then ``u^* = (\\bar\\beta / \\alpha_{i^*})\\, e_{i^*}`` where
 ``i^* = \\arg\\min_i \\{g_i / \\alpha_i : g_i < 0\\}``.
 Returns ``v = u^* + l``. ``O(m)``.
 """
-struct WeightedSimplex{T<:Real} <: LinearOracle
+struct WeightedSimplex{T<:Real} <: AbstractOracle
     α::Vector{T}
     β::T
     lb::Vector{T}

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -21,7 +21,7 @@ user-supplied gradient `∇f!(g, x)`.
 # Arguments
 - `f`: objective function `f(x) -> Real`
 - `∇f!`: in-place gradient `∇f!(g, x)`, writing ``\\nabla f(x)`` into `g`
-- `lmo`: linear minimization oracle (callable `lmo(v, g)` or `<: LinearOracle`)
+- `lmo`: linear minimization oracle (callable `lmo(v, g)` or `<: AbstractOracle`)
 - `x0`: initial feasible point (will be copied)
 
 # Keyword Arguments

--- a/test/test_lmo.jl
+++ b/test/test_lmo.jl
@@ -16,7 +16,7 @@ using Marguerite
 using Test
 using LinearAlgebra
 
-@testset "Linear Oracles" begin
+@testset "Oracles" begin
 
     @testset "Simplex" begin
         lmo = Simplex()


### PR DESCRIPTION
* tweak README and bilevel docs

* deduplicate docs, fix tone, and reorder pages

Remove duplicated bilevel example from README, index.md, and differentiation.md. Rewrite README as a lean landing page with problem math and bilevel_solve quick start. Rewrite docs index as a navigation guide. Reorder doc pages by learning progression (oracles before bilevel). Fix marketing tone across bilevel, examples, and tutorial pages.



* rename LinearOracle → AbstractOracle and add SVG constraint set diagrams

Rename the abstract type to follow Julia convention (fixes #15). Add hand-crafted SVG illustrations for each oracle's feasible region in the docs.



* move constraint labels outside feasible regions in oracle SVGs



* fix PR review: rename Linear Oracles, add README vars, restore rrule docs

- Rename "Linear Oracles" → "Oracles" in docs heading, index ref, and testset
- Update CLAUDE.md oracle count from 5 to 6 for consistency with README
- Add missing variable definitions (x_target, x0, θ, η) to README bilevel snippet
- Restore full bilevel rrule usage section in differentiation.md



* fix consistency: update birth year in CLAUDE.md and oracle name in docs index



---------