### PR TITLE
Code quality overhaul: reduce duplication, type-generic constructors, in-place HVP

### DIFF
--- a/src/Marguerite.jl
+++ b/src/Marguerite.jl
@@ -65,6 +65,17 @@ export ActiveConstraints, active_set, materialize
     # Auto-gradient solve
     solve(_f, _lmo, _x0; max_iters=5)
 
+    # AdaptiveStepSize path
+    solve(_f, _∇f!, _lmo, _x0; max_iters=5, step_rule=AdaptiveStepSize())
+
+    # Box oracle solve
+    _box = Box(zeros(2), ones(2))
+    solve(_f, _∇f!, _box, [0.5, 0.5]; max_iters=5)
+
+    # Knapsack oracle solve
+    _knap = Knapsack(1, 2)
+    solve(_f, _∇f!, _knap, [0.5, 0.5]; max_iters=5)
+
     # Parametric manual-gradient solve
     _fp(x, θ) = 0.5 * dot(x, _H * x) - dot(θ, x)
     _∇fp!(g, x, θ) = (g .= _H * x .- θ)
@@ -74,13 +85,22 @@ export ActiveConstraints, active_set, materialize
     # Parametric auto-gradient solve
     solve(_fp, _lmo, _x0, _θ; max_iters=5)
 
-    # rrule + pullback (precompile HVP/CG/implicit-diff paths)
+    # rrule + pullback (manual gradient, precompile HVP/CG/implicit-diff paths)
     (_x_star, _res), _pb = rrule(solve, _fp, _∇fp!, _lmo, _x0, _θ; max_iters=5, diff_λ=1e-2)
     _pb((2.0 .* _x_star, nothing))
+
+    # rrule + pullback (auto gradient, precompile joint HVP path)
+    (_x_star2, _res2), _pb2 = rrule(solve, _fp, _lmo, _x0, _θ; max_iters=5, diff_λ=1e-2)
+    _pb2((2.0 .* _x_star2, nothing))
 
     # ParametricOracle path
     _plmo = ParametricBox(θ -> zeros(2), θ -> ones(2))
     solve(_fp, _∇fp!, _plmo, [0.5, 0.5], _θ; max_iters=5)
+
+    # bilevel_solve (manual and auto gradient)
+    _outer(x) = sum(x .^ 2)
+    bilevel_solve(_outer, _fp, _∇fp!, _lmo, _x0, _θ; max_iters=5, diff_λ=1e-2)
+    bilevel_solve(_outer, _fp, _lmo, _x0, _θ; max_iters=5, diff_λ=1e-2)
 end
 
 end

--- a/src/bilevel.jl
+++ b/src/bilevel.jl
@@ -12,6 +12,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ------------------------------------------------------------------
+# Shared bilevel core: active_set → outer gradient → KKT solve → θ̄
+# ------------------------------------------------------------------
+
+"""
+    _bilevel_core(outer_loss, f, x_star, θ, lmo, cross_deriv_fn; kwargs...)
+
+Compute the bilevel parameter gradient after the inner solve.
+
+Shared by all `bilevel_solve` variants. Computes the outer-loss gradient at
+`x_star`, solves the KKT adjoint system, and combines objective and (optional)
+constraint sensitivity into ``\\bar{\\theta}``.
+"""
+function _bilevel_core(outer_loss, f, x_star, θ, lmo, cross_deriv_fn;
+                        plmo=nothing, backend, hvp_backend,
+                        tol, diff_cg_maxiter, diff_cg_tol, diff_λ)
+    as = active_set(lmo, x_star; tol=max(tol, _ACTIVE_SET_MIN_TOL))
+    x̄ = DI.gradient(outer_loss, backend, x_star)
+
+    u, μ_bound, μ_eq, cg_result = _kkt_adjoint_solve(
+        f, hvp_backend, x_star, θ, x̄, as;
+        cg_maxiter=diff_cg_maxiter, cg_tol=diff_cg_tol, cg_λ=diff_λ)
+
+    θ̄ = cross_deriv_fn(u)
+
+    if plmo !== nothing
+        θ̄_con = _constraint_pullback(plmo, θ, x_star, μ_bound, μ_eq, as, backend)
+        θ̄ = θ̄ .+ θ̄_con
+    end
+
+    if !cg_result.converged
+        @warn "bilevel_solve: CG did not converge (residual=$(cg_result.residual_norm), iters=$(cg_result.iterations)): θ̄ may be inaccurate" maxlog=3
+    end
+
+    return θ̄, cg_result
+end
+
+# ------------------------------------------------------------------
+# bilevel_solve: standard oracle (manual + auto gradient)
+# ------------------------------------------------------------------
+
 """
     bilevel_solve(outer_loss, f, ∇f!, lmo, x0, θ; kwargs...) -> (x_star, θ_grad, cg_result)
 
@@ -44,18 +85,11 @@ function bilevel_solve(outer_loss, f, ∇f!::Function, lmo, x0, θ;
         @warn "inner solve did not converge (gap=$(inner_result.gap), iters=$(inner_result.iterations)): bilevel gradient may be inaccurate" maxlog=3
     end
 
-    as = active_set(lmo, x_star; tol=max(tol, _ACTIVE_SET_MIN_TOL))
-    x̄ = DI.gradient(outer_loss, backend, x_star)
-
     ∇_x_f_of_θ = _make_∇_x_f_of_θ(∇f!, x_star)
-
-    # KKT adjoint handles both interior (empty active set → fast path) and boundary solutions
-    θ̄, _, _, _, cg_result = _kkt_implicit_pullback(f, ∇_x_f_of_θ, x_star, θ, x̄, as,
-                                                     backend, hvp_backend;
-                                                     cg_maxiter=diff_cg_maxiter, cg_tol=diff_cg_tol, cg_λ=diff_λ)
-    if !cg_result.converged
-        @warn "bilevel_solve: CG did not converge (residual=$(cg_result.residual_norm), iters=$(cg_result.iterations)): θ̄ may be inaccurate" maxlog=3
-    end
+    cross_deriv_fn = u -> _cross_derivative_manual(∇_x_f_of_θ, u, θ, backend)
+    θ̄, cg_result = _bilevel_core(outer_loss, f, x_star, θ, lmo, cross_deriv_fn;
+                                   plmo=nothing, backend, hvp_backend,
+                                   tol, diff_cg_maxiter, diff_cg_tol, diff_λ)
     return x_star, θ̄, cg_result
 end
 
@@ -79,15 +113,10 @@ function bilevel_solve(outer_loss, f, lmo, x0, θ;
         @warn "inner solve did not converge (gap=$(inner_result.gap), iters=$(inner_result.iterations)): bilevel gradient may be inaccurate" maxlog=3
     end
 
-    as = active_set(lmo, x_star; tol=max(tol, _ACTIVE_SET_MIN_TOL))
-    x̄ = DI.gradient(outer_loss, backend, x_star)
-
-    # KKT adjoint handles both interior (empty active set → fast path) and boundary solutions
-    θ̄, _, _, _, cg_result = _kkt_implicit_pullback_hvp(f, x_star, θ, x̄, as, hvp_backend;
-                                                         cg_maxiter=diff_cg_maxiter, cg_tol=diff_cg_tol, cg_λ=diff_λ)
-    if !cg_result.converged
-        @warn "bilevel_solve: CG did not converge (residual=$(cg_result.residual_norm), iters=$(cg_result.iterations)): θ̄ may be inaccurate" maxlog=3
-    end
+    cross_deriv_fn = u -> _cross_derivative_hvp(f, x_star, θ, u, hvp_backend)
+    θ̄, cg_result = _bilevel_core(outer_loss, f, x_star, θ, lmo, cross_deriv_fn;
+                                   plmo=nothing, backend, hvp_backend,
+                                   tol, diff_cg_maxiter, diff_cg_tol, diff_λ)
     return x_star, θ̄, cg_result
 end
 
@@ -136,22 +165,11 @@ function bilevel_solve(outer_loss, f, ∇f!::Function, plmo::ParametricOracle, x
     end
 
     lmo = materialize(plmo, θ)
-    as = active_set(lmo, x_star; tol=max(tol, _ACTIVE_SET_MIN_TOL))
-    x̄ = DI.gradient(outer_loss, backend, x_star)
-
     ∇_x_f_of_θ = _make_∇_x_f_of_θ(∇f!, x_star)
-
-    θ̄_obj, u, μ_bound, μ_eq, cg_result = _kkt_implicit_pullback(
-        f, ∇_x_f_of_θ, x_star, θ, x̄, as, backend, hvp_backend;
-        cg_maxiter=diff_cg_maxiter, cg_tol=diff_cg_tol, cg_λ=diff_λ)
-
-    if !cg_result.converged
-        @warn "bilevel_solve: CG did not converge (residual=$(cg_result.residual_norm), iters=$(cg_result.iterations)): θ̄ may be inaccurate" maxlog=3
-    end
-
-    θ̄_con = _constraint_pullback(plmo, θ, x_star, μ_bound, μ_eq, as, backend)
-    θ̄ = θ̄_obj .+ θ̄_con
-
+    cross_deriv_fn = u -> _cross_derivative_manual(∇_x_f_of_θ, u, θ, backend)
+    θ̄, cg_result = _bilevel_core(outer_loss, f, x_star, θ, lmo, cross_deriv_fn;
+                                   plmo, backend, hvp_backend,
+                                   tol, diff_cg_maxiter, diff_cg_tol, diff_λ)
     return x_star, θ̄, cg_result
 end
 
@@ -174,20 +192,10 @@ function bilevel_solve(outer_loss, f, plmo::ParametricOracle, x0, θ;
     end
 
     lmo = materialize(plmo, θ)
-    as = active_set(lmo, x_star; tol=max(tol, _ACTIVE_SET_MIN_TOL))
-    x̄ = DI.gradient(outer_loss, backend, x_star)
-
-    θ̄_obj, u, μ_bound, μ_eq, cg_result = _kkt_implicit_pullback_hvp(
-        f, x_star, θ, x̄, as, hvp_backend;
-        cg_maxiter=diff_cg_maxiter, cg_tol=diff_cg_tol, cg_λ=diff_λ)
-
-    if !cg_result.converged
-        @warn "bilevel_solve: CG did not converge (residual=$(cg_result.residual_norm), iters=$(cg_result.iterations)): θ̄ may be inaccurate" maxlog=3
-    end
-
-    θ̄_con = _constraint_pullback(plmo, θ, x_star, μ_bound, μ_eq, as, backend)
-    θ̄ = θ̄_obj .+ θ̄_con
-
+    cross_deriv_fn = u -> _cross_derivative_hvp(f, x_star, θ, u, hvp_backend)
+    θ̄, cg_result = _bilevel_core(outer_loss, f, x_star, θ, lmo, cross_deriv_fn;
+                                   plmo, backend, hvp_backend,
+                                   tol, diff_cg_maxiter, diff_cg_tol, diff_λ)
     return x_star, θ̄, cg_result
 end
 

--- a/src/diff_rules.jl
+++ b/src/diff_rules.jl
@@ -212,6 +212,7 @@ function _kkt_adjoint_solve(f, hvp_backend, x_star, θ, x̄, as::ActiveConstrain
 
     # Pre-allocate buffers for the CG loop
     w_full = zeros(T, n)
+    hvp_buf = zeros(T, n)  # reusable HVP output buffer (avoids per-call allocation)
     Hw_buf = zeros(T, n_free)
     proj_buf = zeros(T, n_free)
 
@@ -223,9 +224,9 @@ function _kkt_adjoint_solve(f, hvp_backend, x_star, θ, x̄, as::ActiveConstrain
         @inbounds for (j, idx) in enumerate(free)
             w_full[idx] = w_free[j]
         end
-        Hw_full = DI.hvp(fθ, prep_hvp, hvp_backend, x_star, (w_full,))[1]
+        DI.hvp!(fθ, (hvp_buf,), prep_hvp, hvp_backend, x_star, (w_full,))
         @inbounds for (j, idx) in enumerate(free)
-            Hw_buf[j] = Hw_full[idx]
+            Hw_buf[j] = hvp_buf[idx]
         end
         return _null_project!(proj_buf, Hw_buf, a_frees, a_norm_sqs)
     end
@@ -247,8 +248,8 @@ function _kkt_adjoint_solve(f, hvp_backend, x_star, θ, x̄, as::ActiveConstrain
     end
 
     # Compute Hu for multiplier recovery; reuse w_full as residual buffer
-    Hu = DI.hvp(fθ, prep_hvp, hvp_backend, x_star, (u,))[1]
-    @. w_full = x̄_vec - Hu
+    DI.hvp!(fθ, (hvp_buf,), prep_hvp, hvp_backend, x_star, (u,))
+    @. w_full = x̄_vec - hvp_buf
 
     # μ_eq: pre-compute residual_free once, reuse a_frees
     # (must recover μ_eq first, since μ_bound correction depends on it)
@@ -329,38 +330,6 @@ function _cross_derivative_hvp(f, x_star, θ, u, hvp_backend)
 end
 
 # ------------------------------------------------------------------
-# KKT-based implicit pullbacks (with active set)
-# ------------------------------------------------------------------
-
-"""
-    _kkt_implicit_pullback(f, ∇_x_f_of_θ, x_star, θ, x̄, as, backend, hvp_backend; kwargs...)
-
-KKT adjoint pullback with manual gradient. Solves the KKT system on the active
-face, then computes ``\\bar{\\theta}_{\\text{obj}} = -(\\partial(\\nabla_x f)/\\partial\\theta)^T u``.
-"""
-function _kkt_implicit_pullback(f, ∇_x_f_of_θ, x_star, θ, x̄, as::ActiveConstraints,
-                                 backend, hvp_backend;
-                                 cg_maxiter::Int=50, cg_tol::Real=1e-6, cg_λ::Real=1e-4)
-    u, μ_bound, μ_eq, cg_result = _kkt_adjoint_solve(f, hvp_backend, x_star, θ, x̄, as;
-                                                       cg_maxiter, cg_tol, cg_λ)
-    θ̄_obj = _cross_derivative_manual(∇_x_f_of_θ, u, θ, backend)
-    return θ̄_obj, u, μ_bound, μ_eq, cg_result
-end
-
-"""
-    _kkt_implicit_pullback_hvp(f, x_star, θ, x̄, as, hvp_backend; kwargs...)
-
-KKT adjoint pullback with auto-gradient (joint HVP, no nested AD).
-"""
-function _kkt_implicit_pullback_hvp(f, x_star, θ, x̄, as::ActiveConstraints, hvp_backend;
-                                     cg_maxiter::Int=50, cg_tol::Real=1e-6, cg_λ::Real=1e-4)
-    u, μ_bound, μ_eq, cg_result = _kkt_adjoint_solve(f, hvp_backend, x_star, θ, x̄, as;
-                                                       cg_maxiter, cg_tol, cg_λ)
-    θ̄_obj = _cross_derivative_hvp(f, x_star, θ, u, hvp_backend)
-    return θ̄_obj, u, μ_bound, μ_eq, cg_result
-end
-
-# ------------------------------------------------------------------
 # Constraint pullback (constraint sensitivity contribution to θ̄)
 # ------------------------------------------------------------------
 
@@ -436,15 +405,53 @@ function _constraint_pullback(plmo::ParametricOracle, θ, x_star, μ_bound, μ_e
 end
 
 # ------------------------------------------------------------------
-# rrule: solve(f, ∇f!, lmo, x0, θ; ...) -- existing, upgraded to KKT
+# Shared pullback builder (eliminates duplication across 4 rrules)
+# ------------------------------------------------------------------
+
+"""
+    _build_pullback(f, x_star, θ, lmo, cross_deriv_fn, n_tangents; kwargs...)
+
+Construct the pullback closure for implicit differentiation rrules.
+
+`cross_deriv_fn(u) -> θ̄_obj` computes the objective cross-derivative given the
+KKT adjoint direction `u`. The manual-gradient variant uses
+[`_cross_derivative_manual`](@ref); auto-gradient uses [`_cross_derivative_hvp`](@ref).
+
+`n_tangents` is the tangent tuple length (6 for manual-grad, 5 for auto-grad).
+"""
+function _build_pullback(f, x_star, θ, lmo, cross_deriv_fn, n_tangents;
+                          plmo=nothing, backend, hvp_backend,
+                          as_tol, cg_maxiter, cg_tol, cg_λ)
+    function solve_pullback(ȳ)
+        x̄ = ȳ[1]
+        if x̄ isa ChainRulesCore.AbstractZero
+            return ntuple(_ -> NoTangent(), n_tangents)
+        end
+        as = active_set(lmo, x_star; tol=max(as_tol, _ACTIVE_SET_MIN_TOL))
+        u, μ_bound, μ_eq, cg_result = _kkt_adjoint_solve(
+            f, hvp_backend, x_star, θ, x̄, as;
+            cg_maxiter, cg_tol, cg_λ)
+        θ̄ = cross_deriv_fn(u)
+        if plmo !== nothing
+            θ̄ = θ̄ .+ _constraint_pullback(plmo, θ, x_star, μ_bound, μ_eq, as, backend)
+        end
+        if !cg_result.converged
+            @warn "rrule pullback: CG did not converge (residual=$(cg_result.residual_norm), iters=$(cg_result.iterations)): θ̄ may be inaccurate" maxlog=10
+        end
+        return ntuple(i -> i == n_tangents ? θ̄ : NoTangent(), n_tangents)
+    end
+    return solve_pullback
+end
+
+# ------------------------------------------------------------------
+# rrule: solve(f, ∇f!, lmo, x0, θ; ...) — manual gradient
 # ------------------------------------------------------------------
 
 """
 Implicit differentiation rule for `solve(f, ∇f!, lmo, x0, θ; ...)`.
 
-Uses KKT adjoint solve via [`_kkt_implicit_pullback`](@ref), which correctly
-handles both boundary solutions (active constraints) and interior solutions
-(empty active set fast path).
+Uses KKT adjoint solve, which correctly handles both boundary solutions
+(active constraints) and interior solutions (empty active set fast path).
 
 See [Implicit Differentiation](@ref) for the full mathematical derivation.
 """
@@ -455,33 +462,15 @@ function ChainRulesCore.rrule(::typeof(solve), f, ∇f!, lmo, x0, θ;
                               tol::Real=1e-7,
                               kwargs...)
     x_star, result = solve(f, ∇f!, lmo, x0, θ; backend=backend, tol=tol, kwargs...)
-
-    function solve_pullback(ȳ)
-        x̄ = ȳ[1]  # tangent of x
-
-        if x̄ isa ChainRulesCore.AbstractZero
-            return NoTangent(), NoTangent(), NoTangent(), NoTangent(), NoTangent(), NoTangent()
-        end
-
-        as = active_set(lmo, x_star; tol=max(tol, _ACTIVE_SET_MIN_TOL))
-
-        ∇_x_f_of_θ = _make_∇_x_f_of_θ(∇f!, x_star)
-
-        # KKT adjoint handles both interior (empty active set → fast path) and boundary solutions
-        θ̄, _, _, _, cg_result = _kkt_implicit_pullback(f, ∇_x_f_of_θ, x_star, θ, x̄, as,
-                                                         backend, hvp_backend;
-                                                         cg_maxiter=diff_cg_maxiter, cg_tol=diff_cg_tol, cg_λ=diff_λ)
-
-        if !cg_result.converged
-            @warn "rrule pullback: CG did not converge (residual=$(cg_result.residual_norm), iters=$(cg_result.iterations)): θ̄ may be inaccurate" maxlog=10
-        end
-        return NoTangent(), NoTangent(), NoTangent(), NoTangent(), NoTangent(), θ̄
-    end
-
-    return (x_star, result), solve_pullback
+    ∇_x_f_of_θ = _make_∇_x_f_of_θ(∇f!, x_star)
+    cross_deriv_fn = u -> _cross_derivative_manual(∇_x_f_of_θ, u, θ, backend)
+    pb = _build_pullback(f, x_star, θ, lmo, cross_deriv_fn, 6;
+                          plmo=nothing, backend, hvp_backend,
+                          as_tol=tol, cg_maxiter=diff_cg_maxiter, cg_tol=diff_cg_tol, cg_λ=diff_λ)
+    return (x_star, result), pb
 end
 
-# rrule for auto-gradient + θ variant (uses joint HVP, no nested AD)
+# rrule: solve(f, lmo, x0, θ; ...) — auto gradient (joint HVP)
 function ChainRulesCore.rrule(::typeof(solve), f, lmo, x0, θ;
                               backend=DEFAULT_BACKEND,
                               hvp_backend=SECOND_ORDER_BACKEND,
@@ -489,27 +478,11 @@ function ChainRulesCore.rrule(::typeof(solve), f, lmo, x0, θ;
                               tol::Real=1e-7,
                               kwargs...)
     x_star, result = solve(f, lmo, x0, θ; backend=backend, tol=tol, kwargs...)
-
-    function solve_pullback(ȳ)
-        x̄ = ȳ[1]
-
-        if x̄ isa ChainRulesCore.AbstractZero
-            return NoTangent(), NoTangent(), NoTangent(), NoTangent(), NoTangent()
-        end
-
-        as = active_set(lmo, x_star; tol=max(tol, _ACTIVE_SET_MIN_TOL))
-
-        # KKT adjoint handles both interior (empty active set → fast path) and boundary solutions
-        θ̄, _, _, _, cg_result = _kkt_implicit_pullback_hvp(f, x_star, θ, x̄, as, hvp_backend;
-                                                             cg_maxiter=diff_cg_maxiter, cg_tol=diff_cg_tol, cg_λ=diff_λ)
-
-        if !cg_result.converged
-            @warn "rrule pullback: CG did not converge (residual=$(cg_result.residual_norm), iters=$(cg_result.iterations)): θ̄ may be inaccurate" maxlog=10
-        end
-        return NoTangent(), NoTangent(), NoTangent(), NoTangent(), θ̄
-    end
-
-    return (x_star, result), solve_pullback
+    cross_deriv_fn = u -> _cross_derivative_hvp(f, x_star, θ, u, hvp_backend)
+    pb = _build_pullback(f, x_star, θ, lmo, cross_deriv_fn, 5;
+                          plmo=nothing, backend, hvp_backend,
+                          as_tol=tol, cg_maxiter=diff_cg_maxiter, cg_tol=diff_cg_tol, cg_λ=diff_λ)
+    return (x_star, result), pb
 end
 
 # ------------------------------------------------------------------
@@ -530,35 +503,15 @@ function ChainRulesCore.rrule(::typeof(solve), f, ∇f!::Function, plmo::Paramet
                               kwargs...)
     x_star, result = solve(f, ∇f!, plmo, x0, θ; backend=backend, tol=tol, kwargs...)
     lmo = materialize(plmo, θ)
-
-    function solve_pullback(ȳ)
-        x̄ = ȳ[1]
-
-        if x̄ isa ChainRulesCore.AbstractZero
-            return NoTangent(), NoTangent(), NoTangent(), NoTangent(), NoTangent(), NoTangent()
-        end
-
-        as = active_set(lmo, x_star; tol=max(tol, _ACTIVE_SET_MIN_TOL))
-
-        ∇_x_f_of_θ = _make_∇_x_f_of_θ(∇f!, x_star)
-
-        θ̄_obj, u, μ_bound, μ_eq, cg_result = _kkt_implicit_pullback(
-            f, ∇_x_f_of_θ, x_star, θ, x̄, as, backend, hvp_backend;
-            cg_maxiter=diff_cg_maxiter, cg_tol=diff_cg_tol, cg_λ=diff_λ)
-
-        θ̄_con = _constraint_pullback(plmo, θ, x_star, μ_bound, μ_eq, as, backend)
-        θ̄ = θ̄_obj .+ θ̄_con
-
-        if !cg_result.converged
-            @warn "rrule pullback: CG did not converge (residual=$(cg_result.residual_norm), iters=$(cg_result.iterations)): θ̄ may be inaccurate" maxlog=10
-        end
-        return NoTangent(), NoTangent(), NoTangent(), NoTangent(), NoTangent(), θ̄
-    end
-
-    return (x_star, result), solve_pullback
+    ∇_x_f_of_θ = _make_∇_x_f_of_θ(∇f!, x_star)
+    cross_deriv_fn = u -> _cross_derivative_manual(∇_x_f_of_θ, u, θ, backend)
+    pb = _build_pullback(f, x_star, θ, lmo, cross_deriv_fn, 6;
+                          plmo, backend, hvp_backend,
+                          as_tol=tol, cg_maxiter=diff_cg_maxiter, cg_tol=diff_cg_tol, cg_λ=diff_λ)
+    return (x_star, result), pb
 end
 
-# rrule for auto-gradient + ParametricOracle (joint HVP)
+# rrule: solve(f, plmo::ParametricOracle, x0, θ; ...) — auto gradient
 function ChainRulesCore.rrule(::typeof(solve), f, plmo::ParametricOracle, x0, θ;
                               backend=DEFAULT_BACKEND,
                               hvp_backend=SECOND_ORDER_BACKEND,
@@ -567,28 +520,9 @@ function ChainRulesCore.rrule(::typeof(solve), f, plmo::ParametricOracle, x0, θ
                               kwargs...)
     x_star, result = solve(f, plmo, x0, θ; backend=backend, tol=tol, kwargs...)
     lmo = materialize(plmo, θ)
-
-    function solve_pullback(ȳ)
-        x̄ = ȳ[1]
-
-        if x̄ isa ChainRulesCore.AbstractZero
-            return NoTangent(), NoTangent(), NoTangent(), NoTangent(), NoTangent()
-        end
-
-        as = active_set(lmo, x_star; tol=max(tol, _ACTIVE_SET_MIN_TOL))
-
-        θ̄_obj, u, μ_bound, μ_eq, cg_result = _kkt_implicit_pullback_hvp(
-            f, x_star, θ, x̄, as, hvp_backend;
-            cg_maxiter=diff_cg_maxiter, cg_tol=diff_cg_tol, cg_λ=diff_λ)
-
-        θ̄_con = _constraint_pullback(plmo, θ, x_star, μ_bound, μ_eq, as, backend)
-        θ̄ = θ̄_obj .+ θ̄_con
-
-        if !cg_result.converged
-            @warn "rrule pullback: CG did not converge (residual=$(cg_result.residual_norm), iters=$(cg_result.iterations)): θ̄ may be inaccurate" maxlog=10
-        end
-        return NoTangent(), NoTangent(), NoTangent(), NoTangent(), θ̄
-    end
-
-    return (x_star, result), solve_pullback
+    cross_deriv_fn = u -> _cross_derivative_hvp(f, x_star, θ, u, hvp_backend)
+    pb = _build_pullback(f, x_star, θ, lmo, cross_deriv_fn, 5;
+                          plmo, backend, hvp_backend,
+                          as_tol=tol, cg_maxiter=diff_cg_maxiter, cg_tol=diff_cg_tol, cg_λ=diff_λ)
+    return (x_star, result), pb
 end

--- a/src/lmo.jl
+++ b/src/lmo.jl
@@ -62,8 +62,9 @@ struct Simplex{T<:Real, Equality} <: AbstractOracle
     r::T
 end
 
+Simplex(r::T) where {T<:AbstractFloat} = Simplex{T, false}(r)
 Simplex(r::Real) = Simplex{Float64, false}(Float64(r))
-Simplex(; r::Real=1.0) = Simplex{Float64, false}(Float64(r))
+Simplex(; r::Real=1.0) = Simplex(r)
 
 """
     ProbSimplex(r=1.0)
@@ -71,8 +72,9 @@ Simplex(; r::Real=1.0) = Simplex{Float64, false}(Float64(r))
 Convenience constructor for `Simplex{T, true}(r)` -- the probability simplex
 ``\\{x \\ge 0,\\; \\sum x_i = r\\}``.
 """
+ProbSimplex(r::T) where {T<:AbstractFloat} = Simplex{T, true}(r)
 ProbSimplex(r::Real) = Simplex{Float64, true}(Float64(r))
-ProbSimplex(; r::Real=1.0) = Simplex{Float64, true}(Float64(r))
+ProbSimplex(; r::Real=1.0) = ProbSimplex(r)
 
 """
     ProbabilitySimplex(r=1.0)
@@ -256,12 +258,18 @@ v_i = \\begin{cases} l_i & g_i \\ge 0 \\\\ u_i & g_i < 0 \\end{cases}
 struct Box{T<:Real} <: AbstractOracle
     lb::Vector{T}
     ub::Vector{T}
+
+    function Box{T}(lb::Vector{T}, ub::Vector{T}) where {T<:Real}
+        length(lb) == length(ub) || throw(ArgumentError("Box: lb and ub must have equal length"))
+        new{T}(lb, ub)
+    end
 end
 
-function Box(lb::AbstractVector, ub::AbstractVector)
-    length(lb) == length(ub) || throw(ArgumentError("Box: lb and ub must have equal length"))
+Box(lb::AbstractVector{T}, ub::AbstractVector{T}) where {T<:AbstractFloat} =
+    Box{T}(collect(T, lb), collect(T, ub))
+
+Box(lb::AbstractVector, ub::AbstractVector) =
     Box{Float64}(collect(Float64, lb), collect(Float64, ub))
-end
 
 @inline function (lmo::Box)(v::AbstractVector, g::AbstractVector)
     @inbounds @simd for i in eachindex(v, g, lmo.lb, lmo.ub)
@@ -304,7 +312,14 @@ struct WeightedSimplex{T<:Real} <: AbstractOracle
     β_bar::T  # precomputed: β - α'lb
 end
 
+function WeightedSimplex(α::AbstractVector{T}, β::T, lb::AbstractVector{T}) where {T<:AbstractFloat}
+    all(a -> a > zero(a), α) || throw(ArgumentError("WeightedSimplex: all α entries must be strictly positive"))
+    β_bar = β - dot(α, lb)
+    return WeightedSimplex{T}(collect(T, α), β, collect(T, lb), β_bar)
+end
+
 function WeightedSimplex(α::AbstractVector{<:Real}, β::Real, lb::AbstractVector{<:Real})
+    all(a -> a > zero(a), α) || throw(ArgumentError("WeightedSimplex: all α entries must be strictly positive"))
     α_ = collect(Float64, α)
     lb_ = collect(Float64, lb)
     β_ = Float64(β)
@@ -340,6 +355,22 @@ function (lmo::WeightedSimplex)(v::AbstractVector, g::AbstractVector)
 end
 
 # ------------------------------------------------------------------
+# active_set helpers (reduce boilerplate across oracle types)
+# ------------------------------------------------------------------
+
+function _init_active_arrays(::Type{T}, n::Int) where T
+    bound_idx = Int[]; sizehint!(bound_idx, n)
+    bound_val = T[]; sizehint!(bound_val, n)
+    bound_lower = BitVector(); sizehint!(bound_lower, n)
+    free_idx = Int[]; sizehint!(free_idx, n)
+    return bound_idx, bound_val, bound_lower, free_idx
+end
+
+@inline function _push_bound!(bound_idx, bound_val, bound_lower, i, val, is_lower)
+    push!(bound_idx, i); push!(bound_val, val); push!(bound_lower, is_lower)
+end
+
+# ------------------------------------------------------------------
 # active_set: identify active constraints at x*
 # ------------------------------------------------------------------
 
@@ -362,19 +393,12 @@ end
 
 function active_set(lmo::Box{T}, x::AbstractVector; tol::Real=1e-8) where T
     n = length(x)
-    bound_idx = Int[]
-    bound_val = T[]
-    bound_lower = BitVector()
-    free_idx = Int[]
+    bound_idx, bound_val, bound_lower, free_idx = _init_active_arrays(T, n)
     for i in 1:n
         if abs(x[i] - lmo.lb[i]) ≤ tol
-            push!(bound_idx, i)
-            push!(bound_val, lmo.lb[i])
-            push!(bound_lower, true)
+            _push_bound!(bound_idx, bound_val, bound_lower, i, lmo.lb[i], true)
         elseif abs(x[i] - lmo.ub[i]) ≤ tol
-            push!(bound_idx, i)
-            push!(bound_val, lmo.ub[i])
-            push!(bound_lower, false)
+            _push_bound!(bound_idx, bound_val, bound_lower, i, lmo.ub[i], false)
         else
             push!(free_idx, i)
         end
@@ -384,15 +408,10 @@ end
 
 function active_set(lmo::Simplex{T, true}, x::AbstractVector; tol::Real=1e-8) where T
     n = length(x)
-    bound_idx = Int[]
-    bound_val = T[]
-    bound_lower = BitVector()
-    free_idx = Int[]
+    bound_idx, bound_val, bound_lower, free_idx = _init_active_arrays(T, n)
     for i in 1:n
         if abs(x[i]) ≤ tol
-            push!(bound_idx, i)
-            push!(bound_val, zero(T))
-            push!(bound_lower, true)
+            _push_bound!(bound_idx, bound_val, bound_lower, i, zero(T), true)
         else
             push!(free_idx, i)
         end
@@ -404,15 +423,10 @@ end
 
 function active_set(lmo::Simplex{T, false}, x::AbstractVector; tol::Real=1e-8) where T
     n = length(x)
-    bound_idx = Int[]
-    bound_val = T[]
-    bound_lower = BitVector()
-    free_idx = Int[]
+    bound_idx, bound_val, bound_lower, free_idx = _init_active_arrays(T, n)
     for i in 1:n
         if abs(x[i]) ≤ tol
-            push!(bound_idx, i)
-            push!(bound_val, zero(T))
-            push!(bound_lower, true)
+            _push_bound!(bound_idx, bound_val, bound_lower, i, zero(T), true)
         else
             push!(free_idx, i)
         end
@@ -429,15 +443,10 @@ end
 
 function active_set(lmo::WeightedSimplex{T}, x::AbstractVector; tol::Real=1e-8) where T
     n = length(x)
-    bound_idx = Int[]
-    bound_val = T[]
-    bound_lower = BitVector()
-    free_idx = Int[]
+    bound_idx, bound_val, bound_lower, free_idx = _init_active_arrays(T, n)
     for i in 1:n
         if abs(x[i] - lmo.lb[i]) ≤ tol
-            push!(bound_idx, i)
-            push!(bound_val, lmo.lb[i])
-            push!(bound_lower, true)
+            _push_bound!(bound_idx, bound_val, bound_lower, i, lmo.lb[i], true)
         else
             push!(free_idx, i)
         end
@@ -446,7 +455,7 @@ function active_set(lmo::WeightedSimplex{T}, x::AbstractVector; tol::Real=1e-8) 
     eq_normals = Vector{T}[]
     eq_rhs = T[]
     if abs(dot(lmo.α, x) - lmo.β) ≤ tol
-        push!(eq_normals, copy(lmo.α))
+        push!(eq_normals, lmo.α)
         push!(eq_rhs, lmo.β)
     end
     ActiveConstraints{T}(bound_idx, bound_val, bound_lower, free_idx, eq_normals, eq_rhs)
@@ -454,19 +463,12 @@ end
 
 function active_set(lmo::Knapsack, x::AbstractVector{T}; tol::Real=1e-8) where T
     n = length(x)
-    bound_idx = Int[]
-    bound_val = T[]
-    bound_lower = BitVector()
-    free_idx = Int[]
+    bound_idx, bound_val, bound_lower, free_idx = _init_active_arrays(T, n)
     for i in 1:n
         if abs(x[i]) ≤ tol
-            push!(bound_idx, i)
-            push!(bound_val, zero(T))
-            push!(bound_lower, true)
+            _push_bound!(bound_idx, bound_val, bound_lower, i, zero(T), true)
         elseif abs(x[i] - one(T)) ≤ tol
-            push!(bound_idx, i)
-            push!(bound_val, one(T))
-            push!(bound_lower, false)
+            _push_bound!(bound_idx, bound_val, bound_lower, i, one(T), false)
         else
             push!(free_idx, i)
         end
@@ -482,24 +484,15 @@ end
 
 function active_set(lmo::MaskedKnapsack, x::AbstractVector{T}; tol::Real=1e-8) where T
     n = length(x)
-    bound_idx = Int[]
-    bound_val = T[]
-    bound_lower = BitVector()
-    free_idx = Int[]
+    bound_idx, bound_val, bound_lower, free_idx = _init_active_arrays(T, n)
     for i in 1:n
         if lmo.is_masked[i]
             # Masked indices always pinned to 1 (upper bound)
-            push!(bound_idx, i)
-            push!(bound_val, one(T))
-            push!(bound_lower, false)
+            _push_bound!(bound_idx, bound_val, bound_lower, i, one(T), false)
         elseif abs(x[i]) ≤ tol
-            push!(bound_idx, i)
-            push!(bound_val, zero(T))
-            push!(bound_lower, true)
+            _push_bound!(bound_idx, bound_val, bound_lower, i, zero(T), true)
         elseif abs(x[i] - one(T)) ≤ tol
-            push!(bound_idx, i)
-            push!(bound_val, one(T))
-            push!(bound_lower, false)
+            _push_bound!(bound_idx, bound_val, bound_lower, i, one(T), false)
         else
             push!(free_idx, i)
         end
@@ -531,7 +524,9 @@ function materialize(plmo::ParametricBox, θ)
 end
 
 function materialize(plmo::ParametricSimplex{R, Equality}, θ) where {R, Equality}
-    Simplex{Float64, Equality}(Float64(plmo.r_fn(θ)))
+    r_val = plmo.r_fn(θ)
+    T = r_val isa AbstractFloat ? typeof(r_val) : Float64
+    Simplex{T, Equality}(T(r_val))
 end
 
 function materialize(plmo::ParametricWeightedSimplex, θ)

--- a/test/test_differentiation.jl
+++ b/test/test_differentiation.jl
@@ -439,6 +439,27 @@ using ChainRulesCore: ChainRulesCore, rrule, NoTangent
         @test isapprox(θ̄, θ̄_fd; atol=0.05)
     end
 
+    @testset "CG curvature failure path" begin
+        # Near-singular Hessian with λ=0 to trigger curvature failure
+        A = [1.0 1.0; 1.0 1.0]  # singular (rank 1)
+        b = [1.0, 0.0]
+        hvp_fn(d) = A * d
+        u, cg_result = @test_warn "CG encountered near-zero curvature" Marguerite._cg_solve(hvp_fn, b; maxiter=50, tol=1e-10, λ=0.0)
+        @test !cg_result.converged
+    end
+
+    @testset "Active set with loose tolerance" begin
+        lmo = ProbabilitySimplex()
+        # Point near vertex but with small perturbation
+        x_near = [0.999, 0.001]
+        as_tight = Marguerite.active_set(lmo, x_near; tol=1e-8)
+        as_loose = Marguerite.active_set(lmo, x_near; tol=1e-2)
+        # Loose tolerance should identify x[2] ≈ 0 as bound
+        @test 2 in as_loose.bound_indices
+        # Tight tolerance should not (0.001 > 1e-8)
+        @test !(2 in as_tight.bound_indices)
+    end
+
     @testset "Boundary solution (vertex of simplex) -- KKT correctness" begin
         # θ = [10.0, 0.0] pushes x* to vertex e_1 of the probability simplex.
         # At a vertex, the unconstrained Hessian solve would be wrong because

--- a/test/test_lmo.jl
+++ b/test/test_lmo.jl
@@ -169,6 +169,41 @@ using BenchmarkTools
         @test v ≈ [1.0, 1.0, 1.0]
     end
 
+    @testset "WeightedSimplex α validation" begin
+        @test_throws ArgumentError WeightedSimplex([1.0, 0.0], 1.0, [0.0, 0.0])
+        @test_throws ArgumentError WeightedSimplex([1.0, -0.5], 1.0, [0.0, 0.0])
+        # Valid α should not throw
+        lmo = WeightedSimplex([1.0, 2.0], 3.0, [0.0, 0.0])
+        @test lmo isa WeightedSimplex
+    end
+
+    @testset "Type-preserving constructors" begin
+        # Simplex preserves AbstractFloat types
+        @test Simplex(1.0f0) isa Simplex{Float32, false}
+        @test Simplex(1.0) isa Simplex{Float64, false}
+        @test Simplex(1) isa Simplex{Float64, false}  # Integer → Float64
+
+        # ProbSimplex preserves AbstractFloat types
+        @test ProbSimplex(1.0f0) isa Simplex{Float32, true}
+        @test ProbSimplex(1.0) isa Simplex{Float64, true}
+        @test ProbabilitySimplex(2.0f0) isa Simplex{Float32, true}
+
+        # Box preserves AbstractFloat types
+        @test Box(Float32[0, 0], Float32[1, 1]) isa Box{Float32}
+        @test Box([0.0, 0.0], [1.0, 1.0]) isa Box{Float64}
+        @test Box([0, 0], [1, 1]) isa Box{Float64}  # Integer → Float64
+
+        # WeightedSimplex preserves AbstractFloat types
+        @test WeightedSimplex(Float32[1, 2], 3.0f0, Float32[0, 0]) isa WeightedSimplex{Float32}
+        @test WeightedSimplex([1.0, 2.0], 3.0, [0.0, 0.0]) isa WeightedSimplex{Float64}
+
+        # Float32 oracle actually works
+        lmo32 = Simplex(1.0f0)
+        v32 = zeros(Float32, 3)
+        lmo32(v32, Float32[-1, -3, -2])
+        @test v32 ≈ Float32[0, 1, 0]
+    end
+
     @testset "Function as oracle" begin
         # Plain function works as oracle (no subtyping)
         my_lmo(v, g) = (v .= (g .< 0) .* 1.0; v)


### PR DESCRIPTION
## Summary

- **Correctness**: Add `WeightedSimplex` α > 0 constructor validation
- **Elegance**: Extract `_build_pullback` (rrules) and `_bilevel_core` (bilevel) shared helpers, plus `_init_active_arrays`/`_push_bound!` for active_set — eliminates ~250 lines of duplication across diff_rules.jl, bilevel.jl, and lmo.jl
- **Type design**: Type-preserving oracle constructors (`Simplex(1.0f0) → Simplex{Float32}`), with Integer→Float64 fallback for backward compatibility
- **Performance**: In-place `DI.hvp!` in `_kkt_adjoint_solve` saves ~52 vector allocations per pullback; expanded precompile workload (AdaptiveStepSize, Box, Knapsack, auto-grad rrule, bilevel_solve)
- **Tests**: New coverage for α validation, type-preserving constructors, CG curvature failure path, active set tolerance sensitivity

## Test plan

- [x] Full test suite passes (358 tests)
- [x] All existing differentiation/bilevel finite-difference cross-checks pass
- [x] New tests for constructor validation, type preservation, CG edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)