### PR TITLE
graph problems example: clean up types, merge workspaces, nav dropdown

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Marguerite"
 uuid = "7cfbf62e-f66e-40cd-83d7-4baf4195a571"
 version = "0.1.0"
-authors = ["samtalki <talkington@protonmail.com> and contributors"]
+authors = ["samtalki <10187005+samtalki@users.noreply.github.com> and contributors"]
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ $$\min_{x \in \mathcal{C}} f(x)$$
 
 where $\mathcal{C}$ is a compact convex set accessed through a **linear minimization oracle** (LMO).
 
+## Why `Marguerite.jl`?
+
+`Marguerite.jl` is built for **simple and fast bilevel optimization**, meaning optimization programs that appear as
+$$
+\min_{\theta \in \Theta} \ u(x_\star(\theta)) \qquad \mathsf{st} \quad x_\star(\theta) \in \arg\min_{x \in \mathcal{C}(\theta)}\, f(x;\theta).  
+$$
+It achieves this by implementing highly optimized implicit differentiation for a restrictive---but expressive---selection of constraints. It then abstracts that away into a simple, minimalist interface.
+
 ## When to use Marguerite
 
 - You have a constrained convex problem and a **linear minimization oracle** (LMO) for the constraint set
@@ -26,6 +34,7 @@ where $\mathcal{C}$ is a compact convex set accessed through a **linear minimiza
 - You need **projection-free** optimization (simplex, knapsack, matroid, flow polytopes, etc.)
 - You want **bilevel optimization** with constrained inner problems
 - You value a simple, minimal API with zero-allocation inner loops
+
 
 ## Quick Start
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -42,7 +42,7 @@ end
 makedocs(;
     modules=[Marguerite],
     warnonly=[:missing_docs],
-    authors="samtalki <talkington@protonmail.com> and contributors",
+    authors="samtalki <10187005+samtalki@users.noreply.github.com> and contributors",
     sitename="Marguerite.jl",
     format=format_opts,
     pages=[


### PR DESCRIPTION
Rename CongestionWorkspace/Obj/Grad! → GraphCache/Obj/Grad!, merge dual workspaces into single shared cache, remove unused MathOptInterface import, fix heading mismatch (20→10), trim redundant prose sections, and restructure nav with nested Examples dropdown.